### PR TITLE
fix for single get route in imgs

### DIFF
--- a/routes/img_router.py
+++ b/routes/img_router.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, UploadFile, File
+from fastapi.responses import FileResponse
 from database import DB_dependency
-from services.img_service import upload_img, remove_img
+from services.img_service import upload_img, remove_img, get_single_img
 from user.permission import Permission
 
 img_router = APIRouter()
@@ -14,3 +15,8 @@ def upload(db: DB_dependency, album_id: int, file: UploadFile = File()):
 @img_router.delete("/{id}", dependencies=[Permission.require("manage", "Gallery")], response_model=dict[str, str])
 def delete(db: DB_dependency, id: int):
     return remove_img(db, id)
+
+
+@img_router.get("/{id}")
+def get_img(db: DB_dependency, id: int):
+    return get_single_img(db, id)

--- a/seed.py
+++ b/seed.py
@@ -125,7 +125,7 @@ def seed_permissions(db: Session, posts: list[Post_DB]):
     perm5 = Permission_DB(action="manage", target="News")
     perm6 = Permission_DB(action="manage", target="Song")
     perm7 = Permission_DB(action="manage", target="Gallery")
-    perm7 = Permission_DB(action="manage", target="Ads")
+    perm8 = Permission_DB(action="manage", target="Ads")
     posts[0].permissions.append(perm1)
     posts[0].permissions.append(perm2)
     posts[1].permissions.append(perm3)
@@ -133,6 +133,7 @@ def seed_permissions(db: Session, posts: list[Post_DB]):
     posts[1].permissions.append(perm5)
     posts[0].permissions.append(perm6)
     posts[0].permissions.append(perm7)
+    posts[0].permissions.append(perm8)
     db.commit()
 
 

--- a/services/img_service.py
+++ b/services/img_service.py
@@ -1,4 +1,5 @@
 from fastapi import HTTPException, UploadFile, File
+from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 from pathlib import Path
 from db_models.album_model import Album_DB
@@ -42,3 +43,12 @@ def remove_img(db: Session, img_id: int):
     db.commit()
 
     return {"message": "File removed successfully"}
+
+
+def get_single_img(db: Session, img_id: int):
+    img = db.query(Img_DB).filter(Img_DB.id == img_id).one_or_none()
+
+    if img == None:
+        raise HTTPException(404, detail="File not found")
+
+    return FileResponse(f"/{img.album.path}/{img.path}")


### PR DESCRIPTION
Lagt till en get route för att hämta singulära imgs. Just nu skickar man en fileresponse från fastapi men vi kan ändra den i efterhand.