### PR TITLE
makes it easier to make the news widgets in the app

### DIFF
--- a/api_schemas/news_schemas.py
+++ b/api_schemas/news_schemas.py
@@ -1,6 +1,7 @@
 from typing import Annotated
 from pydantic import StringConstraints
 from api_schemas.base_schema import BaseSchema
+from api_schemas.user_schemas import UserInNewsRead
 from helpers.constants import MAX_NEWS_CONTENT, MAX_NEWS_TITLE
 from helpers.types import datetime_utc
 
@@ -12,6 +13,7 @@ class NewsRead(BaseSchema):
     content_sv: str
     content_en: str
     author_id: int
+    author: UserInNewsRead
     created_at: datetime_utc
     bumped_at: datetime_utc | None
     pinned_from: datetime_utc | None

--- a/api_schemas/user_schemas.py
+++ b/api_schemas/user_schemas.py
@@ -36,6 +36,12 @@ class UserInGroupRead(fastapi_users_schemas.BaseUser[int], BaseSchema):
     program: str | None
 
 
+class UserInNewsRead(BaseSchema):
+    id: int
+    first_name: str
+    last_name: str
+
+
 # fastapi-users will take all fields on this model and feed into the user constructor User_DB(...) when /auth/register route is called
 class UserCreate(fastapi_users_schemas.BaseUserCreate, BaseSchema):
     first_name: Annotated[str, StringConstraints(max_length=MAX_FIRST_NAME_LEN)]


### PR DESCRIPTION
Det är fett jobbigt att få news widgetarna att bli bra utan att få med namnet i NewsRead modellen. 

När detta är mergat, behövs det också  att openapi modellerna genereras om i appen och jag kan inte få scripten att fungera.