### PR TITLE
sanitize img paths

### DIFF
--- a/services/img_service.py
+++ b/services/img_service.py
@@ -47,6 +47,13 @@ def upload_img(db: Session, album_id: int, file: UploadFile = File()):
     if ext not in allowed_exts:
         raise HTTPException(400, "file extension not allowed")
 
+    BASE_UPLOAD_DIR = Path("/albums")
+
+    album_dir = (BASE_UPLOAD_DIR / album.path).resolve()
+
+    if not str(album_dir).startswith(str(BASE_UPLOAD_DIR)):
+        raise HTTPException(400, "Invalid album path")
+
     file_path = Path(f"/{album.path}/{salt}{sanitized_filename}{ext}")
     if file_path.is_file():
         raise HTTPException(409, detail="Filename is equal to already existing file")


### PR DESCRIPTION
Added sanitization for when images are written into the database. ChatGPT also recommended to do this: 

```
# Assuming BASE_UPLOAD_DIR is something like Path("/var/app/uploads")
album_dir = (BASE_UPLOAD_DIR / album.path).resolve()

# Prevent path traversal just in case (extra safety)
if not str(album_dir).startswith(str(BASE_UPLOAD_DIR)):
    raise HTTPException(400, "Invalid album path")
```
    
    
Do we want to do that aswell?