### PR TITLE
Limit user search

### DIFF
--- a/routes/user_router.py
+++ b/routes/user_router.py
@@ -146,11 +146,10 @@ def search_users(
             name_filters.append(
                 or_(func.lower(User_DB.first_name) == name.lower(), func.lower(User_DB.last_name) == name.lower())
             )
-            users = users.filter(and_(*name_filters))
         else:
             for term in name.split(" "):
                 name_filters.append(or_(User_DB.first_name.ilike(f"%{term}%"), User_DB.last_name.ilike(f"%{term}%")))
-            users = users.filter(and_(*name_filters))
+        users = users.filter(and_(*name_filters))
 
     if program:
         users = users.filter_by(program=program)


### PR DESCRIPTION
User search by name is now limited at 3 characters, meaning you will have to enter at least 3 characters before the search returns anything. This is to avoid getting very large search results before you have even entered your full search. However, if your short search matches excactly with a name (suck as Bo or Li or whatever) then you will get that result. Also good to note is that spaces are included in this count. If they shouldn't be I will change that.