### PR TITLE
Add Dependabot Use

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # I took this "devcontainers" part from the frontend, seems reasonable to keep
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "uv" 
+    directory: "/" 
+    schedule:
+      interval: "weekly"
+  # Keep GitHub Actions fresh
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
I tested this in a fork and it seemed to work, it gets updates for github actions (like the frontend repo does), all our packages via uv and should also update dev containers, although the last one I couldn't test.

Resolves #460 