### PR TITLE
Fix pytest warnings

### DIFF
--- a/api_schemas/base_schema.py
+++ b/api_schemas/base_schema.py
@@ -4,4 +4,4 @@ from pydantic import BaseModel, ConfigDict
 # Inherit from when creating Pydantic Models
 class BaseSchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
-    # This model_config lets pydantic validate a databse model
+    # This model_config lets pydantic validate a database model

--- a/api_schemas/permission_schemas.py
+++ b/api_schemas/permission_schemas.py
@@ -7,11 +7,8 @@ class PermissionRead(BaseSchema):
     id: int
     action: PERMISSION_TYPE
     target: PERMISSION_TARGET
-
     # This could fail response validation if a permission is left in db but deleted in hardcoded.
     # alternative is to just say "str" for this schemas action and target
-    class Config:
-        from_attributes = True
 
 
 class PermissionCreate(BaseSchema):

--- a/api_schemas/post_schemas.py
+++ b/api_schemas/post_schemas.py
@@ -23,9 +23,6 @@ class PostRead(BaseSchema):
     elected_user_recommended_limit: int
     elected_user_max_limit: int
 
-    class Config:
-        from_attributes = True
-
 
 class PostUpdate(BaseSchema):
     name_sv: str | None = None
@@ -57,6 +54,3 @@ class PostCreate(BaseSchema):
 class PostDoorAccessRead(BaseSchema):
     id: int
     door: DOOR_ACCESSES
-
-    class Config:
-        from_attributes = True

--- a/db_models/user_model.py
+++ b/db_models/user_model.py
@@ -52,7 +52,7 @@ class User_DB(BaseModel_DB, SQLAlchemyBaseUserTable[int]):
 
     program: Mapped[PROGRAM_TYPE] = mapped_column(default="Oklart", init=False)  # program at the guild
 
-    standard_food_preferences: Mapped[list[str]] = mapped_column(JSON, init=False, default=list)
+    standard_food_preferences: Mapped[list[str]] = mapped_column(JSON, init=False, default_factory=list)
 
     other_food_preferences: Mapped[Optional[str]] = mapped_column(init=False, default="")
 

--- a/helpers/db_util.py
+++ b/helpers/db_util.py
@@ -21,7 +21,7 @@ def created_at_column():
 
 
 def latest_modified_column():
-    return mapped_column(default=get_now_utc, onupdate=get_now_utc, init=False)
+    return mapped_column(insert_default=get_now_utc, onupdate=get_now_utc, init=False)
 
 
 def normalize_swedish(text: str) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ click==8.1.7
 cryptography==42.0.1
 dnspython==2.8.0
 email-validator==2.1.0.post1
-fakeredis==2.31.0
+fakeredis==2.35.0
 fastapi==0.115.0
 fastapi-users-db-sqlalchemy-pelicanq==6.0.6
 fastapi-users-pelicanq==13.0.4
@@ -38,7 +38,6 @@ numpy==2.2.4
 oauthlib==3.3.1
 packaging==23.2
 pandas==2.2.3
-passlib==1.7.4
 phonenumbers==9.0.25
 pillow==10.2.0
 pluggy==1.6.0


### PR DESCRIPTION
I got tired of seeing so many warnings, so I fixed them.

What I manually fixed:

- Warning: Support for class-based `config` is deprecated, use ConfigDict instead.

    - This was already set in base_schema.py so we didn't need it. Remove this from some files:
```
class Config:
    from_attributes = True
```

- SADeprecationWarning: Callable object passed to the ``default`` parameter for attribute 'standard_food_preferences' in a ORM-mapped Dataclasses context is ambiguous. [...] If this callable is intended to produce Core level INSERT default values for an underlying ``Column``, use the ``mapped_column.insert_default`` parameter instead.  To establish this callable as providing a default value for instances of the dataclass itself, use the ``default_factory`` dataclasses parameter.
    - We want a default value for the instances here.

- SADeprecationWarning: Callable object passed to the ``default`` parameter for attribute 'latest_modified' in a ORM-mapped Dataclasses context is ambiguous, and this use will raise an error in a future release.  If this callable is intended to produce Core level INSERT default values for an underlying ``Column``, use the ``mapped_column.insert_default`` parameter instead.  To establish this callable as providing a default value for instances of the dataclass itself, use the ``default_factory`` dataclasses parameter.
    - For latest_modified it needs to be set in the database, we want to "produce Core level INSERT default values" (otherwise it runs when we create the python object). We use insert_default. (We alreay have this with the created at column.)


- passlib used crypt which was about to be deprecated in a future python version. It's also been about 6 years since last update. We also don't use it??? It's not required-by any package according to pip and not imported.
    - So I removed it.

- Fakeredis had some warnings which an update fixed.