### PR TITLE
Fixes in registration pipeline

### DIFF
--- a/api_schemas/user_schemas.py
+++ b/api_schemas/user_schemas.py
@@ -18,8 +18,9 @@ class StilIdValidationMixin:
     @field_validator("stil_id", mode="after")
     @classmethod
     def validate_stil_id(cls, value: str | None) -> str | None:
-        if value is None:
+        if value is None or not value.strip():
             return None
+        value = value.strip()
         if not check_stil_id(value):
             raise ValueError("Invalid stil-id")
         return value

--- a/services/user.py
+++ b/services/user.py
@@ -23,9 +23,10 @@ def update_user(user_id: int, data: UserUpdate, db: DB_dependency):
         print("ERROR: Multiple users found with the same ID:", user_id)
         raise HTTPException(500, detail="Multiple users found with the same ID")
 
-    if data.stil_id and not check_stil_id(data.stil_id):
-        raise HTTPException(400, detail="Invalid stil-id")
-    user.stil_id = data.stil_id  # Always allow clearing stil_id
+    if "stil_id" in data.model_fields_set:
+        if data.stil_id and not check_stil_id(data.stil_id):
+            raise HTTPException(400, detail="Invalid stil-id")
+        user.stil_id = data.stil_id  # Explicitly provided, so allow clearing stil_id
 
     VALID_FOOD_PREFS = set(get_args(FOOD_PREFERENCES))
 

--- a/services/user.py
+++ b/services/user.py
@@ -23,10 +23,9 @@ def update_user(user_id: int, data: UserUpdate, db: DB_dependency):
         print("ERROR: Multiple users found with the same ID:", user_id)
         raise HTTPException(500, detail="Multiple users found with the same ID")
 
-    if data.stil_id:
-        if not check_stil_id(data.stil_id):
-            raise HTTPException(400, detail="Invalid stil-id")
-        user.stil_id = data.stil_id
+    if data.stil_id and not check_stil_id(data.stil_id):
+        raise HTTPException(400, detail="Invalid stil-id")
+    user.stil_id = data.stil_id  # Always allow clearing stil_id
 
     VALID_FOOD_PREFS = set(get_args(FOOD_PREFERENCES))
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -28,6 +28,46 @@ def test_register_user_invalid_stil_id(client):
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
+def test_register_user_empty_stil_id(client, admin_token):
+    """An empty stil_id means the optional field was left blank, and should be stored as None"""
+    user_data = user_data_factory(email="test2@example.com", stil_id="")
+    response = client.post("/auth/register", json=user_data)
+
+    assert response.status_code == status.HTTP_201_CREATED, response.text
+    user = client.get(f"/users/admin/{response.json()['id']}", headers=auth_headers(admin_token)).json()
+    assert user["stil_id"] is None
+
+
+@pytest.mark.parametrize("sent_stil_id", ["", None])
+def test_update_user_clear_stil_id(client, member_token, sent_stil_id):
+    """An empty (or null) stil_id on update means the user blanked the optional field, and should clear it"""
+    set_response = client.patch(
+        "/users/update/me",
+        json={"stil_id": "ab1234cd-s"},
+        headers=auth_headers(member_token),
+    )
+    assert set_response.status_code == status.HTTP_200_OK, set_response.text
+    assert set_response.json()["stil_id"] == "ab1234cd-s"
+
+    response = client.patch(
+        "/users/update/me",
+        json={"stil_id": sent_stil_id},
+        headers=auth_headers(member_token),
+    )
+
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert response.json()["stil_id"] is None
+    assert client.get("/users/me", headers=auth_headers(member_token)).json()["stil_id"] is None
+
+
+def test_register_user_password_containing_email_name(client):
+    """The local part of the e-mail may not be used as the password either"""
+    user_data = user_data_factory(email="somename@example.com", password="somename123")
+    response = client.post("/auth/register", json=user_data)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.text
+
+
 def test_register_duplicate_user(client, user1_data):
     """Test registration with duplicate email fails"""
     # Register first user

--- a/user/user_manager.py
+++ b/user/user_manager.py
@@ -30,7 +30,9 @@ class UserManager(IntegerIDMixin, BaseUserManager[User_DB, int]):
         if len(password) < 8:
             raise InvalidPasswordException(reason="Password should be at least 8 characters")
 
-        if user.email.lower() in password.lower():
+        if (user.email.lower() in password.lower()) or (
+            user.email.split("@")[0].lower() in password.lower() and len(user.email.split("@")[0]) > 3
+        ):
             raise InvalidPasswordException(reason="Password should not contain your e-mail")
 
         if not re.search(r"[A-Za-z]", password) or not re.search(r"\d", password):


### PR DESCRIPTION
- **Fix empty stil-id being rejected when registering!!**
- Add clearing of stil-id to user edit route, previously it would see a falsy value and avoid updating
- Update email-in-password check to reject based on the first part of the email (cool_name@example.com can now reject password if cool_name is in it), previously the whole email had to be a substring for the password to be rejected

Added unit regression tests for these three